### PR TITLE
Podkreślnik i myślnik w prefiksie turnieju

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -8,5 +8,4 @@
 </Files>
 
 RewriteEngine On
-RewriteRule ([a-zA-Z0-9]+)(\d)b-(\d+)\.html$ tdd-protocol.php?prefix=$1&round=$2&board=$3
-
+RewriteRule ([a-zA-Z0-9-_]+)(\d)b-(\d+)\.html$ tdd-protocol.php?prefix=$1&round=$2&board=$3


### PR DESCRIPTION
`.htaccess` zakładał, że prefiks turnieju składa się wyłącznie z liter i cyfr.
Zmiana poszerza ten zakres znaków o myślnik i podkreślnik.
Może należy rozważyć, czy rzeczona część wyrażenia regularnego nie powinna być jeszcze bardziej liberalna.