### PR TITLE
Wyróżnianie rozkładów pojedynczego stołu

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -8,5 +8,4 @@
 </Files>
 
 RewriteEngine On
-RewriteRule ([a-zA-Z0-9]+)(\d)b-(\d+)\.html$ tdd-protocol.php?prefix=$1&round=$2&board=$3
-
+RewriteRule ([a-zA-Z0-9-_]+)(\d)b-(\d+)\.html$ tdd-protocol.php?prefix=$1&round=$2&board=$3

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Może to być zachowanie niewystarczające, gdy rozkład jest przeznaczony nie t
 
 ## Instalacja
 
-W katalogu z plikami html na serwerze należy umieścić .htaccess oraz pliki PHP.
+W katalogu z plikami html na serwerze należy umieścić .htaccess oraz pliki PHP, a także w odpowiednich katalogach dodatkowe pliki CSS/JS.
 Reguła w .htaccess zapewnia, że zapytania do plików HTML z protokołami są przekierowywane do tdd-protocol.php, który podejmuje niezbędne działania.
 
 ## Dodanie rozkładów

--- a/css/tdd.css
+++ b/css/tdd.css
@@ -1,3 +1,7 @@
+body > table > tbody > tr.tdd-header > td {
+    border-bottom: 1px solid #006;
+    padding-top: 30px;
+}
 body > table > tbody > tr {
     opacity: 0.2
 }

--- a/css/tdd.css
+++ b/css/tdd.css
@@ -1,0 +1,7 @@
+body > table > tbody > tr {
+    opacity: 0.2
+}
+body > table > tbody > tr.hovered,
+body > table > tbody > tr.specified {
+    opacity: 1.0;
+}

--- a/sklady/tdd.js
+++ b/sklady/tdd.js
@@ -1,0 +1,74 @@
+var TDD = {
+
+    rowSelector: 'body > table > tbody > tr',
+    rowHeaderClass: 'tdd-header',
+
+    findTable: function(element) {
+        var row = element.closest(TDD.rowSelector);
+        var headerRow = row;
+        while (headerRow.length && !headerRow.hasClass(TDD.rowHeaderClass)) {
+            headerRow = headerRow.prev(TDD.rowSelector);
+        }
+        var rows = [];
+        if (headerRow) {
+            rows.push(headerRow[0]);
+            headerRow = headerRow.next(TDD.rowSelector);
+            while (headerRow.length && !headerRow.hasClass(TDD.rowHeaderClass)) {
+                rows.push(headerRow[0]);
+                headerRow = headerRow.next(TDD.rowSelector);
+            }
+        }
+        return $(rows);
+    },
+
+    highlightTable: function(elem) {
+        TDD.findTable(elem).addClass('specified');
+    },
+
+    hoverTable: function(ev) {
+        TDD.findTable($(ev.currentTarget)).addClass('hovered');
+    },
+
+    unhoverTable: function(ev) {
+        TDD.findTable($(ev.currentTarget)).removeClass('hovered');
+    },
+
+    switchTable: function(ev) {
+        var header = TDD.findTable($(ev.currentTarget)).find('h4[id]');
+        location.hash = header.attr('id');
+        ev.stopPropagation();
+    },
+
+    detectReferer: function() {
+        var regex = document.referrer.match(/\d+t(\d+)-\d+\.htm/);
+        if (regex) {
+            return regex[1];
+        }
+        return undefined;
+    },
+
+    bindEvents: function() {
+        $('tr').hover(TDD.hoverTable, TDD.unhoverTable);
+        $('tr').click(TDD.switchTable);
+        $(window).on('hashchange', function() {
+            var table = $(location.hash);
+            if (table.length) {
+                $('.specified').removeClass('specified');
+                TDD.highlightTable(table);
+            } else {
+                var tableNo = TDD.detectReferer();
+                if (tableNo) {
+                    location.hash = '#table-' + tableNo;
+                } else {
+                    $('h4[id]').each(function() { TDD.highlightTable($(this)); });
+                }
+            }
+        });
+    }
+
+};
+
+$(document).ready(function() {
+    TDD.bindEvents();
+    $(window).trigger('hashchange');
+});

--- a/tdd-bootstrap.php
+++ b/tdd-bootstrap.php
@@ -24,7 +24,6 @@ class Protocol {
 
     function output() {
         $content = file_get_contents($this->get_filename());
-        $modified = 0;
 
         $dom = str_get_html($content);
         $header_td1 = $dom->find("/html/body/table/tr/td[class=\"bdcc12\"]", 0);
@@ -48,7 +47,6 @@ class Protocol {
                 if(($score1 !== '' || strpos($contract1, 'A') === 0)
                       && ($score2 !== '' || strpos($contract2, 'A') === 0)) {
                     $insert .= $deal->html();
-                    $modified = 1;
                 } else {
                     $insert .= '<p>...</p>';
                 }
@@ -58,12 +56,10 @@ class Protocol {
             $tr = @$tr->next_sibling();
         }
 
-        if($modified) {
-            $header_tr2 = $header_tr->next_sibling();
-            $header_tr->outertext = '';
-            $header_tr2->outertext = '';
-            $dom->find('/html/body/table/tr', 0)->outertext = '';
-        }
+        $header_tr2 = $header_tr->next_sibling();
+        $header_tr->outertext = '';
+        $header_tr2->outertext = '';
+        $dom->find('/html/body/table/tr', 0)->outertext = '';
 
         $head = $dom->find('/html/head', 0);
         $head->innertext .= '<link rel="stylesheet" type="text/css" href="css/tdd.css" />'

--- a/tdd-bootstrap.php
+++ b/tdd-bootstrap.php
@@ -65,6 +65,15 @@ class Protocol {
             $dom->find('/html/body/table/tr', 0)->outertext = '';
         }
 
+        // replacing meta http-equiv refresh with a javascript refresh to preserve hash in the result page
+        $meta = $head->find('meta');
+        foreach ($meta as $metaTag) {
+            if ($metaTag->hasAttribute('http-equiv') && strtolower($metaTag->getAttribute('http-equiv')) == 'refresh') {
+                $head->innertext = str_replace($metaTag->outertext, '', $head->innertext) . '<script type="text/javascript">setTimeout(function() { location.reload(); }, ' . ($metaTag->getAttribute('content') * 1000) . ');</script>';
+                break;
+            }
+        }
+
         print $dom->outertext;
     }
 

--- a/tdd-bootstrap.php
+++ b/tdd-bootstrap.php
@@ -74,7 +74,8 @@ class Protocol {
         $meta = $head->find('meta');
         foreach ($meta as $metaTag) {
             if ($metaTag->hasAttribute('http-equiv') && strtolower($metaTag->getAttribute('http-equiv')) == 'refresh') {
-                $head->innertext = str_replace($metaTag->outertext, '', $head->innertext) . '<script type="text/javascript">setTimeout(function() { location.reload(); }, ' . ($metaTag->getAttribute('content') * 1000) . ');</script>';
+                $head->innertext .= '<script type="text/javascript">setTimeout(function() { location.reload(); }, ' . ($metaTag->getAttribute('content') * 1000) . ');</script>';
+                $metaTag->outertext = '';  // delete $metaTag
                 break;
             }
         }

--- a/tdd-bootstrap.php
+++ b/tdd-bootstrap.php
@@ -65,6 +65,9 @@ class Protocol {
             $dom->find('/html/body/table/tr', 0)->outertext = '';
         }
 
+        $head = $dom->find('/html/head', 0);
+        $head->innertext .= '<link rel="stylesheet" type="text/css" href="css/tdd.css" />';
+
         // replacing meta http-equiv refresh with a javascript refresh to preserve hash in the result page
         $meta = $head->find('meta');
         foreach ($meta as $metaTag) {

--- a/tdd-bootstrap.php
+++ b/tdd-bootstrap.php
@@ -66,7 +66,9 @@ class Protocol {
         }
 
         $head = $dom->find('/html/head', 0);
-        $head->innertext .= '<link rel="stylesheet" type="text/css" href="css/tdd.css" />';
+        $head->innertext .= '<link rel="stylesheet" type="text/css" href="css/tdd.css" />'
+            . '<script src="https://code.jquery.com/jquery-3.3.1.min.js" type="text/javascript"></script>'
+            . '<script src="sklady/tdd.js" type="text/javascript"></script>';
 
         // replacing meta http-equiv refresh with a javascript refresh to preserve hash in the result page
         $meta = $head->find('meta');

--- a/tdd-bootstrap.php
+++ b/tdd-bootstrap.php
@@ -74,8 +74,7 @@ class Protocol {
         $meta = $head->find('meta');
         foreach ($meta as $metaTag) {
             if ($metaTag->hasAttribute('http-equiv') && strtolower($metaTag->getAttribute('http-equiv')) == 'refresh') {
-                $head->innertext .= '<script type="text/javascript">setTimeout(function() { location.reload(); }, ' . ($metaTag->getAttribute('content') * 1000) . ');</script>';
-                $metaTag->outertext = '';  // delete $metaTag
+                $head->innertext = str_replace($metaTag->outertext, '', $head->innertext) . '<script type="text/javascript">setTimeout(function() { location.reload(); }, ' . ($metaTag->getAttribute('content') * 1000) . ');</script>';
                 break;
             }
         }

--- a/tdd-bootstrap.php
+++ b/tdd-bootstrap.php
@@ -53,7 +53,7 @@ class Protocol {
                     $insert .= '<p>...</p>';
                 }
 
-                $tr->outertext = '<tr class="tdd-header"><td colspan="7" style="border-bottom:1px solid #006;padding-top:30px;">' . $insert . '</td></tr>' . $tr->outertext;
+                $tr->outertext = '<tr class="tdd-header"><td colspan="7">' . $insert . '</td></tr>' . $tr->outertext;
             }
             $tr = @$tr->next_sibling();
         }

--- a/tdd-bootstrap.php
+++ b/tdd-bootstrap.php
@@ -41,18 +41,19 @@ class Protocol {
                 $contract2 = trim(str_replace('&nbsp;', '', $tr->next_sibling()->find('td[class="bdc"]', 0)->innertext));
                 $score2 = trim(str_replace('&nbsp;', '', end($tr->next_sibling()->find('td'))->innertext));
 
+                $deal = $this->deals_by_tables[$table];
+                $insert = "<a href=\"#table-$table\"><h4 id=\"table-$table\">Stół $table &ndash; Rozdanie {$deal->deal_num}</h4></a>";
                 // if is played on both tables of a match
                 // note that the contract field for arbitral scores starts with 'A' (e.g. 'ARB' or 'AAA')
                 if(($score1 !== '' || strpos($contract1, 'A') === 0)
                       && ($score2 !== '' || strpos($contract2, 'A') === 0)) {
-                    $deal = $this->deals_by_tables[$table];
-                    $insert = "<a href=\"#table-$table\"><h4 id=\"table-$table\">Stół $table &ndash; Rozdanie {$deal->deal_num}</h4></a>" . $deal->html();
+                    $insert .= $deal->html();
                     $modified = 1;
                 } else {
-                    $insert = '<p>...</p>';
+                    $insert .= '<p>...</p>';
                 }
 
-                $tr->outertext = '<tr><td colspan="7" style="border-bottom:1px solid #006;padding-top:30px;">' . $insert . '</td></tr>' . $tr->outertext;
+                $tr->outertext = '<tr class="tdd-header"><td colspan="7" style="border-bottom:1px solid #006;padding-top:30px;">' . $insert . '</td></tr>' . $tr->outertext;
             }
             $tr = @$tr->next_sibling();
         }

--- a/tdd-protocol.php
+++ b/tdd-protocol.php
@@ -18,7 +18,12 @@ if($request_uri_ending != '/' . $html_filename) {
 //
 
 $deals_by_tables = load_deals_for_tables($prefix, $round, $board);
-foreach($deals_by_tables as $table => $deal) {
-    $protocol->set_deal($table, $deal);
+if (count($deals_by_tables) > 0) {
+    foreach($deals_by_tables as $table => $deal) {
+        $protocol->set_deal($table, $deal);
+    }
+    echo $protocol->output();
 }
-echo $protocol->output();
+else {
+    readfile($html_filename);
+}


### PR DESCRIPTION
Zmiany sprawiają, że wśród rozkładów wyróżniany jest pojedynczy, bieżący stół, czyli rozwiązują #3.

Po kolei:
 - na stronie wszystkie stoły są domyślnie wyszarzone
 - jeśli w hashu strony znajduje się `#table-X`, to podświetlany jest dany stół (to pozwala również łatwo linkować do rozkładu w kontekście pojedynczego stołu, a także załatwia przewinięcie strony do odpowiedniego stołu)
 - jeśli w hashu nie ma stołu, próbuje się go wykryć z referrera
 - jeśli nie zostanie wykryty, podświetlane są wszystkie stoły

Przykład: pierwsza runda tego turnieju: https://emkael.info/brydz/diff-deals/ivld_rr1_runda1.html
Wczytałem do niej losowe rozkłady, które nie mają żadnego związku z tym turniejem, zignoruj również fakt, że protokół wyświetla butlera.
W pierwszym rozdaniu usunąłem również ręcznie jeden zapis oraz dodałem refresh strony, żeby pokryć więcej scenariuszy.
Można podlinkować pojedyncze rozdanie, np. tak: https://emkael.info/brydz/diff-deals/ivld_rr1_1b-7.html#table-3
Można również podlinkować cały protokół: https://emkael.info/brydz/diff-deals/ivld_rr1_1b-7.html (i bez referrera wyświetli wszystkie stoły).

Do tego przyjąłem następujący sposób przełączania kontekstu (poza nawigacją z kontrolki):
 - najazd myszą na obszar innego stołu tymczasowo podświetla ten stół
 - kliknięcie myszą w obszar innego stołu gasi poprzedni stół i podświetla nowy stół

Ze zmian, które musiałem wprowadzić, poza wprowadzeniem linków do pojedynczego rozkładu (z nagłówka "Stół X - Rozdanie Y"):
 - skrypt PHP zamienia `<meta http-equiv="Refresh">` na JavaScriptowy odpowiednik - przeładowanie poprzez `<meta>` gubiło hash strony (o referrerze nie wspominając)
 - nagłówek "Stół X - Rozdanie Y" dodawany jest również dla rozdań, w których rozkłady są jeszcze ukryte, nie jestem pewien, czy w tamtych rejonach kodu dobrze zrozumiałem logikę zmiennej `$modified`, więc na wszelki wypadek nie ruszałem
 - na potrzeby wykrywania sekcji tabeli dotyczącej jednego stołu, pododawałem trochę klas do elementów

Testowałem pod Chromem, a następnie pobieżnie pod Firefoksem, Operą, IE (11) i Chromem na Androidzie.

Z rzeczy, które jeszcze trochę mi się nie podobają, to że najazdy myszy oraz kliknięcia przewijające stronę są mało płynne. Jest 3 w nocy i nawet nie próbuję myśleć, co można z tym zrobić.

Do tego oryginalna struktura strony z protokołem jest taka, że zdarzenia myszy musiałem przypinać do wierszy tabeli, a czasem kursor z jakichś powodów trafia w martwą przestrzeń między wierszami tabeli i np. stół się nie podświetla.
Można to ulepszyć, zamykając każdy stół w jakiś osobny element - czyli rozbijając tabelę protokołu na wiele odrębnych tabel, ale ta używana biblioteka PHP do modyfikacji DOM trochę mnie przestraszyła swoją prostotą (przykład: dobrą godzinę kombinowałem, jak usunąć element, nie uciekając się do `str_replace` na elemencie nadrzędnym).

Jeśli będziemy testować i poprawiać to rozwiązanie, można by też było jakoś się zabezpieczyć przed cache'owaniem `tdd.js` w przeglądarce.

No i nie wiem, czy 0.2 to właściwa wartość wyszarzenia.

Wygląda na to, że edytor automatycznie wyciął z pliku PHP spacje na końcach linii, sorry.