### PR TITLE
Bugfixy + czasowy ukrywacz

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Program umożliwia wyświetlenie w protokole JFR Teamy na stronie wielu rozkładów rozdań, tj. innego rozkładu dla każdego stołu (lub tylko dla wybranych stołów).
 
-Program posiada również funkcjonalność ukrywania rozkładów i zapisów rozdania, jeśli wszystkie zapisy dla danego rozkładu nie widnieją jeszcze w protokole.
+Program posiada również funkcjonalność ukrywania rozkładów i zapisów rozdania, jeśli wszystkie zapisy dla danego rozkładu nie widnieją jeszcze w protokole - lub do określonego czasu.
 Zapisy ukrywane są również w kontrolkach.
 
 ## Instalacja
@@ -68,3 +68,20 @@ Ukrywacz zostaje włączony dla wszystkich turniejów, których prefiksy są obe
 Ukrywacz działa również dla prefiksów, dla których nie definiuje się różnych rozkładów dla różnych stołów - pod warunkiem umieszczenia ich w pliku `tdd/.ukrywacz`.
 
 Ukrywacz **nie działa** dla żadnego prefiksu nieobecnego w `tdd/.ukrywacz` - nawet jeśli dla prefiksu zdefiniowano różne rozkłady przy różnych stołach.
+
+Alternatywnie do określenia prefiksów w `tdd/.ukrywacz`, można utworzyć konfigurację czasowego ukrywania rozdań, w pliku `tdd/.ukrywacz-times.json`.
+Jest to plik JSON, formatu:
+
+```
+{
+    "PREFIX": {
+        "NR_RUNDY": {
+            "NR_ROZDANIA_1": ZNACZNIK_CZASU_LUB_DATA,
+            "NR_ROZDANIA_2": ZNACZNIK_CZASU_LUB_DATA,
+            "NR_ROZDANIA_3": ZNACZNIK_CZASU_LUB_DATA
+        }
+    }
+}
+```
+
+Rozdania zostaną wówczas odkryte nie wcześniej niż o określonej godzinie w określonej dacie. Jest to ustawienie niezależne od pliku `tdd/.ukrywacz`, to jest jeśli prefiks jest zarówno w pliku JSON, jak i w pliku `tdd/.ukrywacz`, rozdanie zostanie odkryte dopiero po zagraniu na wszystkich stołach, a jeśli jest wyłącznie w pliku JSON, zostanie odkryte o określonej godzinie niezależnie od tego, czy zostało już zagrane.

--- a/sklady/tdd.js
+++ b/sklady/tdd.js
@@ -87,7 +87,12 @@ var TDD = {
                     if ($(hash).length > 0) {
                         location.replace(hash);
                     } else {
-                        location.replace('#table-0');
+                        var detected = TDD.detectTable(hash);
+                        if (detected && detected.attr('id')) {
+                            location.replace('#' + detected.attr('id'));
+                        } else {
+                            location.replace('#table-0');
+                        }
                     }
                 } else {
                     $('h4[id]').each(function() { TDD.highlightTable($(this)); });

--- a/tdd/tdd-bootstrap.php
+++ b/tdd/tdd-bootstrap.php
@@ -7,6 +7,7 @@ function filename_from_url($url) {
 }
 
 define('PREFIXES_FILE', '.ukrywacz');
+define('TIMED_BOARDS_FILE', '.ukrywacz-times.json');
 
 function get_hide_prefixes() {
     return file_exists(PREFIXES_FILE) ? array_filter(
@@ -23,6 +24,7 @@ class Protocol {
         $this->prefix = $prefix;
         $this->round = $round;
         $this->board = $board;
+        $this->__boardDB = new BoardDB();
         if (file_exists('translations.json')) {
             self::$translations = json_decode(file_get_contents('translations.json'), TRUE);
         }
@@ -71,6 +73,9 @@ class Protocol {
     }
 
     private function __played($boards) {
+        if ($this->__boardDB->hideTimedBoards($this->prefix, $this->round, $this->board)) {
+            return FALSE;
+        }
         return self::areBoardsPlayed($boards, $this->__hideResults);
     }
 
@@ -264,8 +269,8 @@ class Scoresheet {
         $this->__table = $table;
         $this->__round = $round;
         $this->__content = str_get_dom(file_get_contents($this->get_filename($this->__filename)));
-        $boardDB = new BoardDB();
-        $this->__db = $boardDB->getDB();
+        $this->__boardDB = new BoardDB();
+        $this->__db = $this->__boardDB->getDB();
         $this->__hide = $hide;
     }
 
@@ -314,11 +319,14 @@ class Scoresheet {
     }
 
     public function is_played($row, $link) {
+        $linkParts = explode('-', $link->href);
+        $boardNumber = intval(substr($linkParts[1], 0, -4));
+        if ($this->__boardDB->hideTimedBoards($this->__prefix, $this->__round, $boardNumber)) {
+            return FALSE;
+        }
         if (!$this->__hide) {
             return TRUE;
         }
-        $linkParts = explode('-', $link->href);
-        $boardNumber = intval(substr($linkParts[1], 0, -4));
         $tables = $this->__get_tables_for_board($boardNumber);
         $boardRows = $this->__get_boards_from_tables($link->href, $tables);
         return Protocol::areBoardsPlayed($boardRows, TRUE);
@@ -460,10 +468,15 @@ class BoardDB {
             $this->__compileRecordDatabase($this->__getRecordFiles(), $this->__dbFile);
         }
         $this->refreshBoardDatabase();
+        $this->_timedBoards = $this->_getTimedBoards();
     }
 
     public function getDB() {
         return $this->__database;
+    }
+
+    public function getTimedDB() {
+        return $this->_timedBoards;
     }
 
     private function __getRecordFiles($directory = '.') {
@@ -567,5 +580,30 @@ class BoardDB {
             $this->__compileRecordDatabase($recordFiles, $this->__dbFile);
             file_put_contents($this->__timestampFile, json_encode($timestamps));
         }
+    }
+
+    private function _getTimedBoards() {
+        if (file_exists(TIMED_BOARDS_FILE)) {
+            $timedDB = json_decode(file_get_contents(TIMED_BOARDS_FILE), TRUE);
+            if ($timedDB) {
+                return $timedDB;
+            }
+        }
+        return array();
+    }
+
+    public function hideTimedBoards($prefix, $round, $board) {
+        if (isset($this->_timedBoards[$prefix])) {
+            if (isset($this->_timedBoards[$prefix][$round])) {
+                if (isset($this->_timedBoards[$prefix][$round][$board])) {
+                    $boardTime = $this->_timedBoards[$prefix][$round][$board];
+                    if (!is_int($boardTime)) {
+                        $boardTime = strtotime($boardTime);
+                    }
+                    return time() < $boardTime;
+                }
+            }
+        }
+        return FALSE;
     }
 }

--- a/tdd/tdd-bootstrap.php
+++ b/tdd/tdd-bootstrap.php
@@ -86,7 +86,7 @@ class Protocol {
             $score = trim(str_replace('&nbsp;', '', $dom->find('td', 5 + $isFirstRow)->innertext));
             $contract = trim(str_replace('&nbsp;', '', $dom->find('td[class="bdc"]', 0)->innertext));
             // contract field for arbitral scores starts with 'A' (e.g. 'ARB' or 'AAA')
-            if ($score == '' && (!strlen($contract) || $contract[0] != 'A')) {
+            if ($score == '' && (!strlen($contract) || strtoupper($contract[0]) != 'A')) {
                 if ($hideResults) {
                     return FALSE;
                 }

--- a/tdd/tdd-protocol.php
+++ b/tdd/tdd-protocol.php
@@ -14,7 +14,9 @@ $board = (int)(array_pop($uri));
 $roundPrefix = implode('b-', $uri);
 
 $database = new BoardDB();
-$hidePrefixes = array_merge(get_hide_prefixes(), array_keys($database->getTimedDB()));
+$nonTimedPrefixes = get_hide_prefixes();
+$timedPrefixes = array_keys($database->getTimedDB());
+$hidePrefixes = array_merge($nonTimedPrefixes, $timedPrefixes);
 
 try {
     // GET parameters pre-parsed by mod_rewrite are used for HTML fallback
@@ -25,7 +27,7 @@ try {
         foreach ($rounds as $round => $boards) {
             // matching each prefix and round in DB to URI
             if (($prefix . $round === $roundPrefix)) {
-                $protocol->set_hide_results(in_array($prefix, $hidePrefixes));
+                $protocol->set_hide_results(in_array($prefix, $nonTimedPrefixes));
                 if (isset($boards[$board])) {
                     foreach($boards[$board] as $table => $deal) {
                         $protocol->set_deal($table, $deal);
@@ -36,14 +38,17 @@ try {
             }
         }
     }
+    // Maybe prefix is just in result hide mode, without diff-deals
     foreach ($hidePrefixes as $prefix) {
         if (substr($roundPrefix, 0, strlen($prefix)) === $prefix) {
-            $protocol->set_hide_results(TRUE);
+            // If it's in non-timed mode, force hide_results
+            // Otherwise, timed hide will kick in
+            $protocol->set_hide_results(in_array($prefix, $nonTimedPrefixes));
             echo $protocol->output();
             exit(0);
         }
     }
-    // here's the fallback
+    // And here's the fallback if it's just a regular protocol
     readfile($html_filename);
 } catch (Exception $e) {
     header('HTTP/1.0 404 Not Found');

--- a/tdd/tdd-protocol.php
+++ b/tdd/tdd-protocol.php
@@ -13,10 +13,10 @@ $board = (int)(array_pop($uri));
 // the rest is compiled back to separate prefix from round later on
 $roundPrefix = implode('b-', $uri);
 
-$hidePrefixes = get_hide_prefixes();
+$database = new BoardDB();
+$hidePrefixes = array_merge(get_hide_prefixes(), array_keys($database->getTimedDB()));
 
 try {
-    $database = new BoardDB();
     // GET parameters pre-parsed by mod_rewrite are used for HTML fallback
     // in case {$prefix}{$round} combo is not matched against board DB
     $protocol = new Protocol($_GET['prefix'], $_GET['round'], $board);

--- a/tdd/tdd-scoresheet.php
+++ b/tdd/tdd-scoresheet.php
@@ -10,7 +10,8 @@ require_once('tdd-bootstrap.php');
 
 try {
     $database = new BoardDB();
-    $hidePrefixes = array_merge(get_hide_prefixes(), array_keys($database->getTimedDB()));
+    $nonTimedPrefixes = get_hide_prefixes();
+    $hidePrefixes = array_merge($nonTimedPrefixes, array_keys($database->getTimedDB()));
     $prefixes = array_merge(
         array_keys($database->getDB()),
         $hidePrefixes
@@ -21,7 +22,7 @@ try {
             $round = intval($uri_match[2]);
             $table = intval($uri_match[3]);
             $segment = intval($uri_match[4]);
-            $scoresheet = new Scoresheet($html_filename, $prefix, $table, $round, in_array($prefix, $hidePrefixes));
+            $scoresheet = new Scoresheet($html_filename, $prefix, $table, $round, in_array($prefix, $nonTimedPrefixes));
             $scoresheet->output();
             exit(0);
         }

--- a/tdd/tdd-scoresheet.php
+++ b/tdd/tdd-scoresheet.php
@@ -10,7 +10,7 @@ require_once('tdd-bootstrap.php');
 
 try {
     $database = new BoardDB();
-    $hidePrefixes = get_hide_prefixes();
+    $hidePrefixes = array_merge(get_hide_prefixes(), array_keys($database->getTimedDB()));
     $prefixes = array_merge(
         array_keys($database->getDB()),
         $hidePrefixes


### PR DESCRIPTION
Dwa pierwsze commity to poprawki błędów, które wyskoczyły w ciągu poprzedniego sezonu ligowego.

Ostatni - długo wyczekiwany czasowy ukrywacz, docelowo pozwalający na pozbycie się starego ukrywacza dla rozdań lig centralnych.
Będę testował w tym tygodniu (mam nadzieję, że przed faktycznym rozpoczęciem gry w DMP :P), ale nie pogardzę, jeśli rzucisz okiem, czy to ma sens.